### PR TITLE
Update README.md regarding vim-plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ use "rafamadriz/friendly-snippets"
 ### With vim-plug
 
 ```vim
-Plug "rafamadriz/friendly-snippets"
+Plug 'rafamadriz/friendly-snippets'
 ```
 
 ### With coc.nvim


### PR DESCRIPTION
`vim-plug` requires single quote for arguments for `Plug`, double quote resulting an error: `E471: Argument required:     Plug`